### PR TITLE
Feat/from chat to biomodel analysis

### DIFF
--- a/backend/app/controllers/llms_controller.py
+++ b/backend/app/controllers/llms_controller.py
@@ -14,8 +14,8 @@ async def get_llm_response(user_prompt: str) -> str:
         str: The final response after processing the user's query.
     """
     try:
-        result = await get_response_with_tools(user_prompt)
-        return result
+        result, bmkeys = await get_response_with_tools(user_prompt)
+        return result, bmkeys
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
 

--- a/backend/app/routes/llms_router.py
+++ b/backend/app/routes/llms_router.py
@@ -16,8 +16,8 @@ async def query_llm(user_prompt: str):
     Returns:
         dict: The final response after processing the prompt with the tools.
     """
-    result = await get_llm_response(user_prompt)
-    return {"response": result}
+    result, bmkeys = await get_llm_response(user_prompt)
+    return {"response": result, "bmkeys": bmkeys}
 
 
 @router.post("/analyse/{biomodel_id}")

--- a/backend/app/services/llms_service.py
+++ b/backend/app/services/llms_service.py
@@ -78,6 +78,8 @@ async def get_response_with_tools(user_prompt: str):
 
     messages.append(response.choices[0].message)
 
+    bmkeys = []
+
     if tool_calls:
         for tool_call in tool_calls:
             # Extract the function name and arguments
@@ -90,6 +92,8 @@ async def get_response_with_tools(user_prompt: str):
             result = await execute_tool(name, args)
 
             logger.info(f"Tool Result: {str(result)[:500]}")
+
+            bmkeys = result.get('unique_model_keys (bmkey)', [])
 
             # Send the result back to the model
             messages.append(
@@ -108,8 +112,7 @@ async def get_response_with_tools(user_prompt: str):
 
     logger.info(f"LLM Response: {final_response}")
 
-    return final_response
-
+    return final_response, bmkeys
 
 async def analyse_biomodel(biomodel_id: str, user_prompt: str):
     # Initialize final response structure

--- a/frontend/app/analyze/[id]/page.tsx
+++ b/frontend/app/analyze/[id]/page.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import React from "react"
+import { useState, useEffect } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Search, Loader2, Dna, Gauge, FlaskConical, Atom, Briefcase, Cog } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { DiagramSection } from "@/components/DiagramSection"
+import { VCMLSection } from "@/components/VCMLSection"
+import { ChatBox } from "@/components/ChatBox"
+
+interface AnalysisResults {
+  title: string
+  description: string
+  diagram: string
+  vcml: string
+  diagramAnalysis: string
+  vcmlAnalysis: string
+  aiAnalysis: string
+}
+
+export default function AnalysisResultsPage({ params }: { params: { id: string } }) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const prompt = searchParams.get('prompt') || ''
+  
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState("")
+  const [results, setResults] = useState<AnalysisResults | null>(null)
+
+  useEffect(() => {
+    const fetchAnalysis = async () => {
+      try {
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL
+        const analyseRes = await fetch(`${apiUrl}/analyse/${params.id}?user_prompt=${encodeURIComponent(prompt)}`, {
+          method: 'POST',
+          headers: { 'accept': 'application/json' },
+        })
+        
+        if (!analyseRes.ok) throw new Error("Failed to analyze biomodel.")
+        const analyseData = await analyseRes.json()
+
+        setResults({
+          title: `Analysis for Biomodel ${params.id}`,
+          description: `Results for biomodel ID ${params.id}.`,
+          diagram: "",
+          vcml: "",
+          diagramAnalysis: analyseData.response?.diagram_analysis || "No diagram analysis available.",
+          vcmlAnalysis: analyseData.response?.vcml_analysis || "No VCML analysis available.",
+          aiAnalysis: analyseData.response?.ai_analysis || "No AI analysis available.",
+        })
+      } catch (err) {
+        setError("Failed to analyze biomodel.")
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchAnalysis()
+  }, [params.id, prompt])
+
+  const handleReset = () => {
+    router.push('/analyze')
+  }
+
+  const quickActions = [
+    { label: "Describe biology of the model", value: "Describe biology of the model", icon: <Dna className="h-4 w-4" /> },
+    { label: "Describe parameters", value: "Describe parameters", icon: <Gauge className="h-4 w-4" /> },
+    { label: "Describe species", value: "Describe species", icon: <Atom className="h-4 w-4" /> },
+    { label: "Describe reactions", value: "Describe reactions", icon: <FlaskConical className="h-4 w-4" /> },
+    { label: "What Applications are used?", value: "What Applications are used?", icon: <Briefcase className="h-4 w-4" /> },
+    { label: "What solvers are used?", value: "What solvers are used?", icon: <Cog className="h-4 w-4" /> },
+  ]
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-white flex flex-col items-center justify-center py-16">
+        <div className="w-16 h-16 mb-6">
+          <Loader2 className="h-16 w-16 animate-spin text-blue-600" />
+        </div>
+        <h2 className="text-2xl font-semibold text-slate-900 mb-2">Analyzing Biomodel</h2>
+        <p className="text-slate-600 mb-8 text-center max-w-md">
+          Our AI is processing the biomodel data and generating comprehensive insights...
+        </p>
+        <div className="w-full max-w-md bg-slate-100 rounded-full h-2.5">
+          <div className="bg-blue-600 h-2.5 rounded-full animate-pulse w-full"></div>
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !results) {
+    return (
+      <div className="min-h-screen bg-white flex flex-col items-center justify-center py-16">
+        <div className="text-center">
+          <h2 className="text-2xl font-semibold text-red-600 mb-2">Error</h2>
+          <p className="text-slate-600 mb-8">{error || "Failed to load analysis results"}</p>
+          <Button onClick={handleReset} className="flex items-center gap-2">
+            <Search className="h-4 w-4" />
+            Try Again
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="container mx-auto p-8 max-w-5xl">
+        <div className="space-y-12">
+          {/* Results Header */}
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-3xl font-bold text-slate-900 mb-1">{results.title}</h2>
+              <p className="text-slate-600">{results.description}</p>
+            </div>
+            <Button variant="outline" onClick={handleReset} className="flex items-center gap-2">
+              <Search className="h-4 w-4" />
+              New Analysis
+            </Button>
+          </div>
+
+          {/* Diagram and Analysis Sections */}
+          <DiagramSection 
+            biomodelId={params.id}
+            diagramAnalysis={results.diagramAnalysis}
+          />
+
+          {/* VCML Sections */}
+          <VCMLSection 
+            biomodelId={params.id}
+            vcmlAnalysis={results.vcmlAnalysis}
+          />
+
+          {/* Chat Box */}
+          <ChatBox
+            startMessage={results.aiAnalysis}
+            quickActions={quickActions}
+            cardTitle="Follow-up Questions"
+            promptPrefix={`Analyze the biomodel with the bmId ${params.id} for the following question: ${prompt}`}
+          />
+        </div>
+      </div>
+    </div>
+  )
+} 

--- a/frontend/app/analyze/page.tsx
+++ b/frontend/app/analyze/page.tsx
@@ -2,10 +2,10 @@
 
 import React from "react"
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import {
   Search,
   MessageSquare,
-  Loader2,
   Dna,
   Gauge,
   FlaskRoundIcon as Flask,
@@ -15,24 +15,6 @@ import {
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { DiagramSection } from "@/components/DiagramSection"
-import { VCMLSection } from "@/components/VCMLSection"
-import { ChatBox } from "@/components/ChatBox"
-
-interface AnalysisState {
-  status: "input" | "loading" | "results"
-  biomodelId: string
-  prompt: string
-  results: {
-    title: string
-    description: string
-    diagram: string
-    vcml: string
-    diagramAnalysis: string
-    vcmlAnalysis: string
-    aiAnalysis: string
-  } | null
-}
 
 interface PromptTemplate {
   title: string
@@ -42,15 +24,9 @@ interface PromptTemplate {
 }
 
 export default function AnalyzePage() {
-  const [state, setState] = useState<AnalysisState>({
-    status: "input",
-    biomodelId: "",
-    prompt: "",
-    results: null,
-  })
-
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState("")
+  const router = useRouter()
+  const [biomodelId, setBiomodelId] = useState("")
+  const [prompt, setPrompt] = useState("")
 
   const promptTemplates: PromptTemplate[] = [
     {
@@ -92,187 +68,83 @@ export default function AnalyzePage() {
   ]
 
   const handlePromptTemplateClick = (prompt: string) => {
-    setState({ ...state, prompt })
+    setPrompt(prompt)
   }
 
-  // Updated handleAnalyze to only handle the analysis endpoint
-  const handleAnalyze = async () => {
-    if (!state.biomodelId.trim() || !state.prompt.trim()) return
-    setState({ ...state, status: "loading" })
-    setIsLoading(true)
-    setError("")
-    try {
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL
-      // Call the /analyse endpoint
-      const analyseRes = await fetch(`${apiUrl}/analyse/${state.biomodelId}?user_prompt=${encodeURIComponent(state.prompt)}`, {
-        method: 'POST',
-        headers: { 'accept': 'application/json' },
-      })
-      if (!analyseRes.ok) throw new Error("Failed to analyze biomodel.")
-      const analyseData = await analyseRes.json()
-
-      // Use the response fields for analysis
-      const aiAnalysis = analyseData.response?.ai_analysis || "No AI analysis available."
-      const diagramAnalysis = analyseData.response?.diagram_analysis || "No diagram analysis available."
-      const vcmlAnalysis = analyseData.response?.vcml_analysis || "No VCML analysis available."
-
-      setState({
-        ...state,
-        status: "results",
-        results: {
-          title: `Analysis for Biomodel ${state.biomodelId}`,
-          description: `Results for biomodel ID ${state.biomodelId}.`,
-          diagram: "",
-          vcml: "",
-          diagramAnalysis,
-          vcmlAnalysis,
-          aiAnalysis,
-        },
-      })
-    } catch (err) {
-      setError("Failed to analyze biomodel.")
-    } finally {
-      setIsLoading(false)
-    }
+  const handleAnalyze = () => {
+    if (!biomodelId.trim() || !prompt.trim()) return
+    router.push(`/analyze/${biomodelId}?prompt=${encodeURIComponent(prompt)}`)
   }
-
-  const handleReset = () => {
-    setState({
-      status: "input",
-      biomodelId: "",
-      prompt: "",
-      results: null,
-    })
-  }
-
-  const quickActions = promptTemplates.map(template => ({
-    label: template.title,
-    icon: template.icon,
-    value: template.prompt
-  }))
 
   return (
     <div className="min-h-screen bg-white flex flex-col justify-center items-center text-slate-900">
       <div className="container mx-auto p-8 max-w-5xl">
-        {state.status === "input" && (
-          <div className="space-y-10 flex flex-col items-center">
-            {/* Enhanced Header */}
-            <div className="text-center mb-10">
-              <h1 className="text-7xl font-extrabold text-blue-600 mb-3">
-                Biomodel AI Analysis
-              </h1>
-              <p className="text-slate-500 text-lg">
-                Unlock insights from your biomodels with the power of AI.
-              </p>
-            </div>
-
-            {/* Enhanced Two large search bars side by side */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-4xl items-center">
-              <div className="relative">
-                <Search className="absolute left-5 top-1/2 transform -translate-y-1/2 h-6 w-6 text-slate-400" />
-                <Input
-                  placeholder="Enter BioModel ID (e.g., 12345)"
-                  value={state.biomodelId}
-                  onChange={(e) => setState({ ...state, biomodelId: e.target.value })}
-                  className="text-xl h-16 pl-14 pr-6 bg-slate-50 border-2 border-slate-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 rounded-xl shadow-sm transition-all duration-300 ease-in-out text-slate-900 placeholder-slate-400"
-                />
-              </div>
-              <div className="relative">
-                <MessageSquare className="absolute left-5 top-1/2 transform -translate-y-1/2 h-6 w-6 text-slate-400" />
-                <Input
-                  placeholder="What would you like to analyze?"
-                  value={state.prompt}
-                  onChange={(e) => setState({ ...state, prompt: e.target.value })}
-                  className="text-xl h-16 pl-14 pr-6 bg-slate-50 border-2 border-slate-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 rounded-xl shadow-sm transition-all duration-300 ease-in-out text-slate-900 placeholder-slate-400"
-                />
-              </div>
-            </div>
-
-            {/* Enhanced Example Prompts */}
-            <div className="w-full max-w-4xl pt-4">
-              <p className="text-center text-slate-500 mb-5 text-sm">Or try one of these example prompts:</p>
-              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-                {promptTemplates.map((template, index) => (
-                  <Button
-                    key={index}
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handlePromptTemplateClick(template.prompt)}
-                    className={`group flex items-center justify-start text-left p-3 rounded-lg border-slate-300 bg-white hover:bg-slate-50 hover:border-blue-500 transition-all duration-200 ease-in-out shadow-xs text-slate-700 hover:text-blue-600`}
-                  >
-                    <div className={`mr-3 p-1.5 rounded-md ${template.color.replace("bg-", "bg-opacity-10 ").replace("text-", "text-").replace("border-", "border-opacity-20 ")}`}>
-                      {React.cloneElement(template.icon, { className: "h-5 w-5" })}
-                    </div>
-                    <span className="text-xs font-medium group-hover:font-semibold">{template.title}</span>
-                  </Button>
-                ))}
-              </div>
-            </div>
-
-            {/* Analyze Button */}
-            <div className="flex justify-center mt-8">
-              <Button
-                onClick={handleAnalyze}
-                disabled={!state.biomodelId.trim() || !state.prompt.trim()}
-                className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-6 text-xl rounded-xl"
-              >
-                <Search className="h-6 w-6 mr-2" />
-                Analyze Biomodel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {state.status === "loading" && (
-          <div className="flex flex-col items-center justify-center py-16">
-            <div className="w-16 h-16 mb-6">
-              <Loader2 className="h-16 w-16 animate-spin text-blue-600" />
-            </div>
-            <h2 className="text-2xl font-semibold text-slate-900 mb-2">Analyzing Biomodel</h2>
-            <p className="text-slate-600 mb-8 text-center max-w-md">
-              Our AI is processing the biomodel data and generating comprehensive insights...
+        <div className="space-y-10 flex flex-col items-center">
+          {/* Enhanced Header */}
+          <div className="text-center mb-10">
+            <h1 className="text-7xl font-extrabold text-blue-600 mb-3">
+              Biomodel AI Analysis
+            </h1>
+            <p className="text-slate-500 text-lg">
+              Unlock insights from your biomodels with the power of AI.
             </p>
-            <div className="w-full max-w-md bg-slate-100 rounded-full h-2.5">
-              <div className="bg-blue-600 h-2.5 rounded-full animate-pulse w-full"></div>
+          </div>
+
+          {/* Enhanced Two large search bars side by side */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-4xl items-center">
+            <div className="relative">
+              <Search className="absolute left-5 top-1/2 transform -translate-y-1/2 h-6 w-6 text-slate-400" />
+              <Input
+                placeholder="Enter BioModel ID (e.g., 12345)"
+                value={biomodelId}
+                onChange={(e) => setBiomodelId(e.target.value)}
+                className="text-xl h-16 pl-14 pr-6 bg-slate-50 border-2 border-slate-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 rounded-xl shadow-sm transition-all duration-300 ease-in-out text-slate-900 placeholder-slate-400"
+              />
+            </div>
+            <div className="relative">
+              <MessageSquare className="absolute left-5 top-1/2 transform -translate-y-1/2 h-6 w-6 text-slate-400" />
+              <Input
+                placeholder="What would you like to analyze?"
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                className="text-xl h-16 pl-14 pr-6 bg-slate-50 border-2 border-slate-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 rounded-xl shadow-sm transition-all duration-300 ease-in-out text-slate-900 placeholder-slate-400"
+              />
             </div>
           </div>
-        )}
 
-        {state.status === "results" && state.results && (
-          <div className="space-y-12">
-            {/* Results Header */}
-            <div className="flex items-center justify-between">
-              <div>
-                <h2 className="text-3xl font-bold text-slate-900 mb-1">{state.results.title}</h2>
-                <p className="text-slate-600">{state.results.description}</p>
-              </div>
-              <Button variant="outline" onClick={handleReset} className="flex items-center gap-2">
-                <Search className="h-4 w-4" />
-                New Analysis
-              </Button>
+          {/* Enhanced Example Prompts */}
+          <div className="w-full max-w-4xl pt-4">
+            <p className="text-center text-slate-500 mb-5 text-sm">Or try one of these example prompts:</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              {promptTemplates.map((template, index) => (
+                <Button
+                  key={index}
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePromptTemplateClick(template.prompt)}
+                  className={`group flex items-center justify-start text-left p-3 rounded-lg border-slate-300 bg-white hover:bg-slate-50 hover:border-blue-500 transition-all duration-200 ease-in-out shadow-xs text-slate-700 hover:text-blue-600`}
+                >
+                  <div className={`mr-3 p-1.5 rounded-md ${template.color.replace("bg-", "bg-opacity-10 ").replace("text-", "text-").replace("border-", "border-opacity-20 ")}`}>
+                    {React.cloneElement(template.icon, { className: "h-5 w-5" })}
+                  </div>
+                  <span className="text-xs font-medium group-hover:font-semibold">{template.title}</span>
+                </Button>
+              ))}
             </div>
-
-            {/* Diagram and Analysis Sections */}
-            <DiagramSection 
-              biomodelId={state.biomodelId}
-              diagramAnalysis={state.results.diagramAnalysis}
-            />
-
-            {/* VCML Sections */}
-            <VCMLSection 
-              biomodelId={state.biomodelId}
-              vcmlAnalysis={state.results.vcmlAnalysis}
-            />
-
-            {/* Chat Box */}
-            <ChatBox
-              startMessage={state.results.aiAnalysis}
-              quickActions={quickActions}
-              cardTitle="Follow-up Questions"
-              promptPrefix={`Analyze the biomodel with the bmId ${state.biomodelId} for the following question: ${state.prompt}`}
-            />
           </div>
-        )}
+
+          {/* Analyze Button */}
+          <div className="flex justify-center mt-8">
+            <Button
+              onClick={handleAnalyze}
+              disabled={!biomodelId.trim() || !prompt.trim()}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-6 text-xl rounded-xl"
+            >
+              <Search className="h-6 w-6 mr-2" />
+              Analyze Biomodel
+            </Button>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/frontend/app/analyze/page.tsx
+++ b/frontend/app/analyze/page.tsx
@@ -338,6 +338,7 @@ export default function AnalyzePage() {
               startMessage={state.results.aiAnalysis}
               quickActions={quickActions}
               cardTitle="Follow-up Questions"
+              promptPrefix={`Analyze the biomodel with the bmId ${state.biomodelId} for the following question: ${state.prompt}`}
             />
           </div>
         )}

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -1,0 +1,210 @@
+import React, { useState, useRef, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { MarkdownRenderer } from "@/components/markdown-renderer"
+import { MessageSquare, Send, Bot, User, Loader2 } from "lucide-react"
+
+interface Message {
+  id: string
+  role: "user" | "assistant"
+  content: string
+  timestamp: Date
+}
+
+interface QuickAction {
+  label: string
+  icon: React.ReactNode
+  value: string
+}
+
+interface ChatBoxProps {
+  startMessage: string
+  quickActions: QuickAction[]
+  cardTitle: string
+}
+
+export const ChatBox: React.FC<ChatBoxProps> = ({ startMessage, quickActions, cardTitle }) => {
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      id: "1",
+      role: "assistant",
+      content: startMessage,
+      timestamp: new Date(),
+    },
+  ])
+  const [inputMessage, setInputMessage] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+  }
+
+  useEffect(() => {
+    scrollToBottom()
+  }, [messages])
+
+  const handleQuickAction = (message: string) => {
+    setInputMessage("")
+    handleSendMessage(message)
+  }
+
+  const handleSendMessage = async (overrideMessage?: string) => {
+    const msg = overrideMessage ?? inputMessage
+    if (!msg.trim()) return
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      role: "user",
+      content: msg,
+      timestamp: new Date(),
+    }
+    setMessages((prev) => [...prev, userMessage])
+    setInputMessage("")
+    setIsLoading(true)
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/query?user_prompt=${encodeURIComponent(msg)}`,
+        {
+          method: "POST",
+          headers: { accept: "application/json" },
+          body: "",
+        },
+      )
+      const data = await res.json()
+      const aiResponse = data.response || "Sorry, I didn't get a response from the server."
+      const assistantMessage: Message = {
+        id: (Date.now() + 1).toString(),
+        role: "assistant",
+        content: aiResponse,
+        timestamp: new Date(),
+      }
+      setMessages((prev) => [...prev, assistantMessage])
+    } catch (error) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: (Date.now() + 2).toString(),
+          role: "assistant",
+          content: "There was an error connecting to the backend. Please try again.",
+          timestamp: new Date(),
+        },
+      ])
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      handleSendMessage()
+    }
+  }
+
+  return (
+    <Card className="h-[600px] flex flex-col shadow-sm border-slate-200">
+      <CardHeader className="bg-slate-50 border-b border-slate-200 flex-shrink-0">
+        <CardTitle className="flex items-center gap-2 text-slate-900">
+          <MessageSquare className="h-5 w-5" />
+          {cardTitle}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex-1 p-0 overflow-hidden">
+        <ScrollArea className="h-full p-4">
+          <div className="space-y-4">
+            {messages.map((message) => (
+              <div
+                key={message.id}
+                className={`flex gap-3 ${message.role === "user" ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={`flex gap-3 max-w-[80%] ${
+                    message.role === "user" ? "flex-row-reverse" : "flex-row"
+                  }`}
+                >
+                  <div
+                    className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
+                      message.role === "user" ? "bg-blue-600 text-white" : "bg-slate-200 text-slate-700"
+                    }`}
+                  >
+                    {message.role === "user" ? <User className="h-4 w-4" /> : <Bot className="h-4 w-4" />}
+                  </div>
+                  <div
+                    className={`rounded-lg p-3 ${
+                      message.role === "user" ? "bg-blue-600 text-white" : "bg-white border border-slate-200"
+                    }`}
+                  >
+                    {message.role === "user" ? (
+                      <div className="whitespace-pre-wrap text-sm leading-relaxed">{message.content}</div>
+                    ) : (
+                      <MarkdownRenderer content={message.content} />
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+            <div className="flex gap-3 justify-start">
+              <div className="w-8 h-8 rounded-full bg-slate-200 text-slate-700 flex items-center justify-center flex-shrink-0">
+                <Bot className="h-4 w-4" />
+              </div>
+              <div className="bg-white border border-slate-200 rounded-lg p-3 max-w-[80%]">
+                <div className="text-sm text-slate-600 mb-3">Try these quick actions:</div>
+                <div className="space-y-2">
+                  {quickActions.map((action, idx) => (
+                    <Button
+                      key={idx}
+                      variant="outline"
+                      size="sm"
+                      className="w-full justify-start text-xs h-8"
+                      onClick={() => handleQuickAction(action.value)}
+                    >
+                      {action.icon}
+                      {action.label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+            {isLoading && (
+              <div className="flex gap-3 justify-start">
+                <div className="w-8 h-8 rounded-full bg-slate-200 text-slate-700 flex items-center justify-center flex-shrink-0">
+                  <Bot className="h-4 w-4" />
+                </div>
+                <div className="bg-white border border-slate-200 rounded-lg p-3">
+                  <div className="flex items-center gap-2 text-slate-600">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span className="text-sm">AI is thinking...</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+          <div ref={messagesEndRef} />
+        </ScrollArea>
+      </CardContent>
+      <div className="border-t border-slate-200 p-4 flex-shrink-0">
+        <div className="flex gap-2">
+          <Input
+            ref={inputRef}
+            value={inputMessage}
+            onChange={(e) => setInputMessage(e.target.value)}
+            onKeyPress={handleKeyPress}
+            placeholder="Ask any questions about VCell biomodels..."
+            className="flex-1 border-slate-300 focus:border-blue-500"
+            disabled={isLoading}
+          />
+          <Button
+            onClick={() => handleSendMessage()}
+            disabled={isLoading || !inputMessage.trim()}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4"
+          >
+            <Send className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+} 

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -77,6 +77,7 @@ export const ChatBox: React.FC<ChatBoxProps> = ({ startMessage, quickActions, ca
       )
       const data = await res.json()
       const aiResponse = data.response || "Sorry, I didn't get a response from the server."
+      console.log(aiResponse)
       const assistantMessage: Message = {
         id: (Date.now() + 1).toString(),
         role: "assistant",

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -23,9 +23,10 @@ interface ChatBoxProps {
   startMessage: string
   quickActions: QuickAction[]
   cardTitle: string
+  promptPrefix?: string
 }
 
-export const ChatBox: React.FC<ChatBoxProps> = ({ startMessage, quickActions, cardTitle }) => {
+export const ChatBox: React.FC<ChatBoxProps> = ({ startMessage, quickActions, cardTitle, promptPrefix }) => {
   const [messages, setMessages] = useState<Message[]>([
     {
       id: "1",
@@ -65,8 +66,9 @@ export const ChatBox: React.FC<ChatBoxProps> = ({ startMessage, quickActions, ca
     setInputMessage("")
     setIsLoading(true)
     try {
+      const finalPrompt = promptPrefix ? `${promptPrefix} ${msg}` : msg
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/query?user_prompt=${encodeURIComponent(msg)}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/query?user_prompt=${encodeURIComponent(finalPrompt)}`,
         {
           method: "POST",
           headers: { accept: "application/json" },

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -48,6 +48,23 @@ export const ChatBox: React.FC<ChatBoxProps> = ({ startMessage, quickActions, ca
     scrollToBottom()
   }, [messages])
 
+  // Helper function to format biomodel IDs as hyperlinks
+  const formatBiomodelIds = (content: string, bmkeys: string[]): string => {
+    if (!bmkeys || bmkeys.length === 0) return content
+    
+    let formattedContent = content
+    
+    // Replace biomodel IDs with hyperlinks
+    bmkeys.forEach(bmId => {
+      const regex = new RegExp(`\\b${bmId}\\b`, 'g')
+      const encodedPrompt = encodeURIComponent(`Describe model`)
+      const link = `[${bmId}](/analyze/${bmId}?prompt=${encodedPrompt})`
+      formattedContent = formattedContent.replace(regex, link)
+    })
+    
+    return formattedContent
+  }
+
   const handleQuickAction = (message: string) => {
     setInputMessage("")
     handleSendMessage(message)
@@ -77,11 +94,16 @@ export const ChatBox: React.FC<ChatBoxProps> = ({ startMessage, quickActions, ca
       )
       const data = await res.json()
       const aiResponse = data.response || "Sorry, I didn't get a response from the server."
-      console.log(aiResponse)
+      const bmkeys = data.bmkeys || []
+      
+      // Format the response to include hyperlinks for biomodel IDs
+      const formattedResponse = formatBiomodelIds(aiResponse, bmkeys)
+      
+      console.log(formattedResponse)
       const assistantMessage: Message = {
         id: (Date.now() + 1).toString(),
         role: "assistant",
-        content: aiResponse,
+        content: formattedResponse,
         timestamp: new Date(),
       }
       setMessages((prev) => [...prev, assistantMessage])

--- a/frontend/components/DiagramSection.tsx
+++ b/frontend/components/DiagramSection.tsx
@@ -1,0 +1,49 @@
+import React from "react"
+import { BarChart3Icon as Diagram3, Search } from "lucide-react"
+
+interface DiagramSectionProps {
+  diagramUrl: string
+  diagramAnalysis: string
+}
+
+export const DiagramSection: React.FC<DiagramSectionProps> = ({ diagramUrl, diagramAnalysis }) => {
+  return (
+    <>
+      {/* Diagram Section */}
+      <div className="bg-white border border-slate-200 rounded-lg shadow-sm overflow-hidden">
+        <div className="bg-slate-50 border-b border-slate-200 px-6 py-4">
+          <h3 className="text-xl font-semibold text-slate-900 flex items-center gap-2">
+            <Diagram3 className="h-5 w-5" />
+            Biomodel Diagram
+          </h3>
+        </div>
+        <div className="p-6">
+          <div className="flex flex-col items-center">
+            <div className="bg-slate-50 border border-slate-200 rounded-lg p-4 mb-4 w-full">
+              <img
+                src={diagramUrl || "/placeholder.svg"}
+                alt="Biomodel Diagram"
+                className="max-w-full h-auto mx-auto"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Diagram Analysis Section */}
+      <div className="bg-white border border-slate-200 rounded-lg shadow-sm overflow-hidden">
+        <div className="bg-slate-50 border-b border-slate-200 px-6 py-4">
+          <h3 className="text-xl font-semibold text-slate-900 flex items-center gap-2">
+            <Search className="h-5 w-5" />
+            Diagram Analysis
+          </h3>
+        </div>
+        <div className="p-6">
+          <div className="prose max-w-none">
+            <div className="whitespace-pre-wrap text-slate-800 leading-relaxed">{diagramAnalysis}</div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+} 

--- a/frontend/components/DiagramSection.tsx
+++ b/frontend/components/DiagramSection.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { BarChart3Icon as Diagram3, Search } from "lucide-react"
+import { MarkdownRenderer } from "./markdown-renderer"
 
 interface DiagramSectionProps {
   diagramUrl: string
@@ -40,7 +41,7 @@ export const DiagramSection: React.FC<DiagramSectionProps> = ({ diagramUrl, diag
         </div>
         <div className="p-6">
           <div className="prose max-w-none">
-            <div className="whitespace-pre-wrap text-slate-800 leading-relaxed">{diagramAnalysis}</div>
+            <MarkdownRenderer content={diagramAnalysis} />
           </div>
         </div>
       </div>

--- a/frontend/components/DiagramSection.tsx
+++ b/frontend/components/DiagramSection.tsx
@@ -1,13 +1,47 @@
-import React from "react"
-import { BarChart3Icon as Diagram3, Search } from "lucide-react"
+import React, { useEffect, useState } from "react"
+import { BarChart3Icon as Diagram3, Search, Loader2 } from "lucide-react"
 import { MarkdownRenderer } from "./markdown-renderer"
 
 interface DiagramSectionProps {
-  diagramUrl: string
+  biomodelId: string
   diagramAnalysis: string
 }
 
-export const DiagramSection: React.FC<DiagramSectionProps> = ({ diagramUrl, diagramAnalysis }) => {
+export const DiagramSection: React.FC<DiagramSectionProps> = ({ biomodelId, diagramAnalysis }) => {
+  const [diagramUrl, setDiagramUrl] = useState<string>("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    const fetchDiagram = async () => {
+      setIsLoading(true)
+      setError("")
+      try {
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL
+        const res = await fetch(`${apiUrl}/biomodel/${biomodelId}/diagram/image`)
+        const contentType = res.headers.get("content-type")
+        if (res.ok && contentType && contentType.startsWith("image")) {
+          const blob = await res.blob()
+          const imageUrl = URL.createObjectURL(blob)
+          setDiagramUrl(imageUrl)
+        } else if (contentType && contentType.includes("application/json")) {
+          const data = await res.json()
+          setError(data.detail || "Diagram not found.")
+        } else {
+          setError("Unexpected response from server.")
+        }
+      } catch (err) {
+        setError("Failed to fetch diagram.")
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    if (biomodelId) {
+      fetchDiagram()
+    }
+  }, [biomodelId])
+
   return (
     <>
       {/* Diagram Section */}
@@ -21,11 +55,19 @@ export const DiagramSection: React.FC<DiagramSectionProps> = ({ diagramUrl, diag
         <div className="p-6">
           <div className="flex flex-col items-center">
             <div className="bg-slate-50 border border-slate-200 rounded-lg p-4 mb-4 w-full">
-              <img
-                src={diagramUrl || "/placeholder.svg"}
-                alt="Biomodel Diagram"
-                className="max-w-full h-auto mx-auto"
-              />
+              {isLoading ? (
+                <div className="flex justify-center items-center h-48">
+                  <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+                </div>
+              ) : error ? (
+                <div className="text-red-500 text-center p-4">{error}</div>
+              ) : (
+                <img
+                  src={diagramUrl || "/placeholder.svg"}
+                  alt="Biomodel Diagram"
+                  className="max-w-full h-auto mx-auto"
+                />
+              )}
             </div>
           </div>
         </div>

--- a/frontend/components/VCMLSection.tsx
+++ b/frontend/components/VCMLSection.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { FileText } from "lucide-react"
 import XMLViewer from 'react-xml-viewer'
+import { MarkdownRenderer } from "./markdown-renderer"
 
 interface VCMLSectionProps {
   vcml: string
@@ -33,7 +34,7 @@ export const VCMLSection: React.FC<VCMLSectionProps> = ({ vcml, vcmlAnalysis }) 
         </div>
         <div className="p-6">
           <div className="prose max-w-none">
-            <div className="whitespace-pre-wrap text-slate-800 leading-relaxed">{vcmlAnalysis}</div>
+            <MarkdownRenderer content={vcmlAnalysis} />
           </div>
         </div>
       </div>

--- a/frontend/components/VCMLSection.tsx
+++ b/frontend/components/VCMLSection.tsx
@@ -1,14 +1,48 @@
-import React from "react"
-import { FileText } from "lucide-react"
+import React, { useEffect, useState } from "react"
+import { FileText, Loader2 } from "lucide-react"
 import XMLViewer from 'react-xml-viewer'
 import { MarkdownRenderer } from "./markdown-renderer"
 
 interface VCMLSectionProps {
-  vcml: string
+  biomodelId: string
   vcmlAnalysis: string
 }
 
-export const VCMLSection: React.FC<VCMLSectionProps> = ({ vcml, vcmlAnalysis }) => {
+export const VCMLSection: React.FC<VCMLSectionProps> = ({ biomodelId, vcmlAnalysis }) => {
+  const [vcml, setVcml] = useState<string>("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    const fetchVcml = async () => {
+      setIsLoading(true)
+      setError("")
+      try {
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL
+        const res = await fetch(`${apiUrl}/biomodel/${biomodelId}/biomodel.vcml`)
+        if (!res.ok) {
+          setError("Failed to fetch VCML from backend.")
+          setVcml("")
+        } else {
+          let text = await res.text()
+          if (text.startsWith('"') && text.endsWith('"')) {
+            text = text.slice(1, -1)
+          }
+          setVcml(text)
+        }
+      } catch (err) {
+        setError("Failed to fetch VCML from backend.")
+        setVcml("")
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    if (biomodelId) {
+      fetchVcml()
+    }
+  }, [biomodelId])
+
   return (
     <>
       {/* VCML File Section */}
@@ -20,7 +54,15 @@ export const VCMLSection: React.FC<VCMLSectionProps> = ({ vcml, vcmlAnalysis }) 
           </h3>
         </div>
         <div className="max-h-[400px] overflow-y-auto p-6">
-          <XMLViewer xml={vcml} />
+          {isLoading ? (
+            <div className="flex justify-center items-center h-48">
+              <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+            </div>
+          ) : error ? (
+            <div className="text-red-500 text-center p-4">{error}</div>
+          ) : (
+            <XMLViewer xml={vcml} />
+          )}
         </div>
       </div>
 

--- a/frontend/components/VCMLSection.tsx
+++ b/frontend/components/VCMLSection.tsx
@@ -1,0 +1,42 @@
+import React from "react"
+import { FileText } from "lucide-react"
+import XMLViewer from 'react-xml-viewer'
+
+interface VCMLSectionProps {
+  vcml: string
+  vcmlAnalysis: string
+}
+
+export const VCMLSection: React.FC<VCMLSectionProps> = ({ vcml, vcmlAnalysis }) => {
+  return (
+    <>
+      {/* VCML File Section */}
+      <div className="bg-white border border-slate-200 rounded-lg shadow-sm overflow-hidden">
+        <div className="bg-slate-50 border-b border-slate-200 px-6 py-4 flex items-center justify-between">
+          <h3 className="text-xl font-semibold text-slate-900 flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            VCML File
+          </h3>
+        </div>
+        <div className="max-h-[400px] overflow-y-auto p-6">
+          <XMLViewer xml={vcml} />
+        </div>
+      </div>
+
+      {/* VCML Analysis Section */}
+      <div className="bg-white border border-slate-200 rounded-lg shadow-sm overflow-hidden">
+        <div className="bg-slate-50 border-b border-slate-200 px-6 py-4">
+          <h3 className="text-xl font-semibold text-slate-900 flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            VCML Analysis
+          </h3>
+        </div>
+        <div className="p-6">
+          <div className="prose max-w-none">
+            <div className="whitespace-pre-wrap text-slate-800 leading-relaxed">{vcmlAnalysis}</div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+} 


### PR DESCRIPTION
**PR Summary:**

* Refactored chat logic into a reusable `ChatBox` component with support for dynamic prompt prefixes.
* Added `DiagramSection` and `VCMLSection` components for displaying diagrams and VCML.
* Integrated new sections into Analyze Page and replaced raw analysis text with a Markdown renderer.
* Simplified Analyze Page; created `AnalysisResultsPage` for dedicated results display.
* Enhanced LLM responses: now return biomodel keys and format biomodel IDs as hyperlinks.
