### PR TITLE
#28 Fix Inconsistent Hyperlink Formatting for Biomodel IDs in ChatBox

### DIFF
--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -78,20 +78,23 @@ export const ChatBox: React.FC<ChatBoxProps> = ({ startMessage, quickActions, ca
 
   // Helper function to format biomodel IDs as hyperlinks
   const formatBiomodelIds = (content: string, bmkeys: string[]): string => {
-    if (!bmkeys || bmkeys.length === 0) return content
-    
-    let formattedContent = content
-    
+    if (!bmkeys || bmkeys.length === 0) return content;
+
+    let formattedContent = content;
+
+    console.log("bmkeys:", bmkeys);
+
     // Replace biomodel IDs with hyperlinks
     bmkeys.forEach(bmId => {
-      const regex = new RegExp(`\\b${bmId}\\b`, 'g')
-      const encodedPrompt = encodeURIComponent(`Describe model`)
-      const link = `[${bmId}](/analyze/${bmId}?prompt=${encodedPrompt})`
-      formattedContent = formattedContent.replace(regex, link)
-    })
-    
-    return formattedContent
-  }
+      const searchString = `${bmId}`;
+      const encodedPrompt = encodeURIComponent(`Describe model`);
+      const link = `[${bmId}](/analyze/${bmId}?prompt=${encodedPrompt})`;
+      const replacementString = `${link}`;
+      formattedContent = formattedContent.replaceAll(searchString, replacementString);
+    });
+
+    return formattedContent;
+  };
 
   const handleQuickAction = (message: string) => {
     setInputMessage("")
@@ -307,4 +310,4 @@ export const ChatBox: React.FC<ChatBoxProps> = ({ startMessage, quickActions, ca
       </div>
     </Card>
   )
-} 
+}


### PR DESCRIPTION
## **Summary:**

* Addresses **issue** #28   related to inconsistent formatting of biomodel ID links on the `/chat` page.
* Replaces **regex-based replacement** with `replaceAll` for more consistent and accurate matching.
* Ensures **all biomodel IDs** provided in `bmkeys` are reliably converted into **hyperlinked markdown format**.
